### PR TITLE
Update 5.internal-document-search-deploy.yml

### DIFF
--- a/.github/workflows/5.internal-document-search-deploy.yml
+++ b/.github/workflows/5.internal-document-search-deploy.yml
@@ -1,8 +1,13 @@
 name: '5.internal-document-search-deployment'
 
+# on:
+#   schedule:
+#     - cron: '0 23 * * *'
+
 on:
-  schedule:
-    - cron: '0 23 * * *'
+  pull_request:
+    branches:
+    - main
 
 jobs:
   deploy:


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/5.internal-document-search-deploy.yml` file. The changes modify the trigger for the workflow, switching from a scheduled trigger to a trigger on pull requests to the main branch.

Here are the details:

* [`.github/workflows/5.internal-document-search-deploy.yml`](diffhunk://#diff-06557e125e7850bf393f1d5191ac1ef3791594805dc79d40d103f6c5b961f5a2R3-R10): The workflow trigger has been changed from a scheduled cron job to a trigger on pull requests to the main branch. This change means that the workflow will now run whenever a pull request is made to the main branch, rather than on a set schedule.

